### PR TITLE
Вкатываем кнопки слайдера

### DIFF
--- a/source/js/modules/rules.js
+++ b/source/js/modules/rules.js
@@ -25,7 +25,7 @@ export default () => {
   });
 
   rulesItems[rulesItems.length - 1].addEventListener(`animationend`, (evt) => {
-    if (evt.animationName === `moveLeft`) {
+    if (evt.animationName === `slideInRight`) {
       setActive(rulesBtn);
     }
   });

--- a/source/scss/animations/keyframes.scss
+++ b/source/scss/animations/keyframes.scss
@@ -1,0 +1,68 @@
+@keyframes zoomIn {
+  0% {
+    transform: scale(0);
+  }
+  80% {
+    transform: scale(1.3);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes slideInRight {
+  0% {
+    transform: translateX(3rem);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes growInRight {
+  0% {
+    left: 100%;
+  }
+  100% {
+    left: 0;
+  }
+}
+
+@keyframes rollInLeft {
+  0% {
+    transform: translateX(-150%) rotateZ(-180deg);
+  }
+  60% {
+    transform: translateX(15%) rotateZ(18deg);
+  }
+  90% {
+    transform: translateX(-5%) rotateZ(-6deg);
+  }
+  100% {
+    transform: translateX(0) rotateZ(0);
+  }
+}
+
+@keyframes rollInRight {
+  0% {
+    transform: translateX(150%) rotateZ(180deg);
+  }
+  60% {
+    transform: translateX(-15%) rotateZ(-18deg);
+  }
+  90% {
+    transform: translateX(5%) rotateZ(6deg);
+  }
+  100% {
+    transform: translateX(0) rotateZ(0);
+  }
+}

--- a/source/scss/animations/rules.scss
+++ b/source/scss/animations/rules.scss
@@ -40,15 +40,15 @@ $delay: 0.5s;
 
 .rules__item.active {
   &::before {
-    animation-name: popOut;
+    animation-name: zoomIn;
   }
 
   &::after {
-    animation-name: appear;
+    animation-name: fadeIn;
   }
 
   p {
-    animation-name: appear, moveLeft;
+    animation-name: fadeIn, slideInRight;
   }
 }
 
@@ -74,13 +74,13 @@ $delay: 0.5s;
 }
 
 .rules__link.active {
-  animation-name: appear;
+  animation-name: fadeIn;
 
   &::before {
-    animation-name: growLeft;
+    animation-name: growInRight;
   }
 
   .rules__link-text {
-    animation-name: appear;
+    animation-name: fadeIn;
   }
 }

--- a/source/scss/animations/rules.scss
+++ b/source/scss/animations/rules.scss
@@ -1,6 +1,8 @@
 $delay: 0.5s;
 
 .rules__item {
+  will-change: transform;
+
   &::before {
     animation-duration: 0.35s;
     animation-timing-function: ease-out;
@@ -80,44 +82,5 @@ $delay: 0.5s;
 
   .rules__link-text {
     animation-name: appear;
-  }
-}
-
-@keyframes popOut {
-  0% {
-    transform: scale(0);
-  }
-  80% {
-    transform: scale(1.3);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-@keyframes appear {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes moveLeft {
-  0% {
-    transform: translateX(3rem);
-  }
-  100% {
-    transform: translateX(0);
-  }
-}
-
-@keyframes growLeft {
-  0% {
-    left: 100%;
-  }
-  100% {
-    left: 0;
   }
 }

--- a/source/scss/animations/slider.scss
+++ b/source/scss/animations/slider.scss
@@ -32,4 +32,19 @@
       }
     }
   }
+
+  .slider__control {
+    animation-duration: 1s, 0.6s;
+    animation-timing-function: cubic-bezier(0.15, 0.15, 0.1, 1), ease;
+    animation-delay: 0.5s;
+    animation-fill-mode: both;
+  }
+
+  .slider__control--prev {
+    animation-name: rollInLeft, fadeIn;
+  }
+
+  .slider__control--next {
+    animation-name: rollInRight, fadeIn;
+  }
 }

--- a/source/scss/style.scss
+++ b/source/scss/style.scss
@@ -20,6 +20,7 @@
 @import "blocks/slider.scss";
 @import "blocks/social-block.scss";
 
+@import "animations/keyframes.scss";
 @import "animations/accent-typography.scss";
 @import "animations/form.scss";
 @import "animations/intro.scss";


### PR DESCRIPTION
Добрый день. Не понимаю как правильно реализовать один нюанс и буду рад, если подскажете корректный подход.

Неактивные кнопки слайдера, по-умолчанию, полупрозрачные. В анимации в последнем кадре `opacity: 100%`. По окончании анимации кнопки становятся полупрозрачными либо мгновенно (с опцией `animation-fill-mode: backwards/none`), `transition: opacity` для более гладкого перехода не помогает, либо не становятся полупрозрачными вообще (с опцией `animation-fill-mode: forwards/both`).

Понимаю почему так происходит, но как сделать, чтобы после анимации кнопки становились полупрозрачными придумать не могу.
Делать дополнительную анимацию или добавлять `opacity: 50%` для внутренних элементов неактивных кнопок (типа `.slider__control > *`) вроде как overhead...

---
:mortar_board: [Вкатываем кнопки слайдера](https://up.htmlacademy.ru/animation/1/user/1315149/tasks/7)

:boom: https://htmlacademy-animation.github.io/1315149-magic-vacation-1/6/